### PR TITLE
Adding notebook-path argument to parser.

### DIFF
--- a/nbpages/check_nbs.py
+++ b/nbpages/check_nbs.py
@@ -67,7 +67,7 @@ def main(max_commits_to_check_in_range=50):
                              'argument for "git rev-list", and git must be '
                              'installed and accessible from the calling shell.')
     parser.add_argument('--notebook-path', default='.', dest='nb-path',
-                        help='Relative path of notebooks')
+                        help='Relative path of notebooks to check')
     args = parser.parse_args()
 
     logging.basicConfig()

--- a/nbpages/check_nbs.py
+++ b/nbpages/check_nbs.py
@@ -74,7 +74,7 @@ def main(max_commits_to_check_in_range=50):
     log.setLevel(logging.INFO)
     if args.range is None:
         if args.nb_path:
-            success = visit_content_nbs(nb_path, execution_check)
+            success = visit_content_nbs(args.nb_path, execution_check)
         else:
             success = visit_content_nbs('.', execution_check)
     else:

--- a/nbpages/check_nbs.py
+++ b/nbpages/check_nbs.py
@@ -66,14 +66,14 @@ def main(max_commits_to_check_in_range=50):
                         help='A range of git commits to check. Must be a valid'
                              'argument for "git rev-list", and git must be '
                              'installed and accessible from the calling shell.')
-    parser.add_argument('--notebook-path', default='.', dest='nb-path',
+    parser.add_argument('--notebook-path', default='.', dest='nb_path',
                         help='Relative path of notebooks to check')
     args = parser.parse_args()
 
     logging.basicConfig()
     log.setLevel(logging.INFO)
     if args.range is None:
-        success = visit_content_nbs(args.nb-path, execution_check)
+        success = visit_content_nbs(args.nb_path, execution_check)
 
     else:
         initial_branch = subprocess.check_output('git rev-parse --abbrev-ref HEAD', shell=True).decode().strip()
@@ -99,7 +99,7 @@ def main(max_commits_to_check_in_range=50):
                 log.info('Checking SHA "{}"'.format(sha))
                 subprocess.check_output('git checkout -q -f {}'.format(sha), shell=True)
                 
-                if not visit_content_nbs(args.nb-path, execution_check):
+                if not visit_content_nbs(args.nb_path, execution_check):
                     success = False
 
         finally:

--- a/nbpages/check_nbs.py
+++ b/nbpages/check_nbs.py
@@ -66,17 +66,15 @@ def main(max_commits_to_check_in_range=50):
                         help='A range of git commits to check. Must be a valid'
                              'argument for "git rev-list", and git must be '
                              'installed and accessible from the calling shell.')
-    parser.add_argument('--notebook-path', default='.', dest='nb_path',
+    parser.add_argument('--notebook-path', default='.', dest='nb-path',
                         help='Relative path of notebooks')
     args = parser.parse_args()
 
     logging.basicConfig()
     log.setLevel(logging.INFO)
     if args.range is None:
-        if args.nb_path:
-            success = visit_content_nbs(args.nb_path, execution_check)
-        else:
-            success = visit_content_nbs('.', execution_check)
+        success = visit_content_nbs(args.nb-path, execution_check)
+
     else:
         initial_branch = subprocess.check_output('git rev-parse --abbrev-ref HEAD', shell=True).decode().strip()
         if initial_branch == 'HEAD':
@@ -101,12 +99,9 @@ def main(max_commits_to_check_in_range=50):
                 log.info('Checking SHA "{}"'.format(sha))
                 subprocess.check_output('git checkout -q -f {}'.format(sha), shell=True)
                 
-                if args.nb_path:
-                    if not visit_content_nbs(args.nb_path, execution_check):
-                        success = False
-                else:
-                    if not visit_content_nbs('.', execution_check):
-                        success = False
+                if not visit_content_nbs(args.nb-path, execution_check):
+                    success = False
+
         finally:
             subprocess.check_output('git checkout ' + initial_branch, shell=True)
             if stash is not None:

--- a/nbpages/check_nbs.py
+++ b/nbpages/check_nbs.py
@@ -101,8 +101,8 @@ def main(max_commits_to_check_in_range=50):
                 log.info('Checking SHA "{}"'.format(sha))
                 subprocess.check_output('git checkout -q -f {}'.format(sha), shell=True)
                 
-                if nb_path:
-                    if not visit_content_nbs(nb_path, execution_check):
+                if args.nb_path:
+                    if not visit_content_nbs(args.nb_path, execution_check):
                         success = False
                 else:
                     if not visit_content_nbs('.', execution_check):

--- a/nbpages/converter.py
+++ b/nbpages/converter.py
@@ -389,6 +389,7 @@ def make_parser(parser=None):
     parser.add_argument('--report', default=None, dest='report_file',
                         help='The path and file name to write a Junit XML '
                              'report to. Extension will always be .xml')
+
     return parser
 
 

--- a/nbpages/converter.py
+++ b/nbpages/converter.py
@@ -390,6 +390,9 @@ def make_parser(parser=None):
                         help='The path and file name to write a Junit XML '
                              'report to. Extension will always be .xml')
 
+    parser.add_argument("--notebook-path", default='.' dest='nb-path',
+                        help='The path to notebooks you wish to convert.')
+
     return parser
 
 

--- a/nbpages/converter.py
+++ b/nbpages/converter.py
@@ -389,10 +389,6 @@ def make_parser(parser=None):
     parser.add_argument('--report', default=None, dest='report_file',
                         help='The path and file name to write a Junit XML '
                              'report to. Extension will always be .xml')
-
-    parser.add_argument("--notebook-path", default='.' dest='nb-path',
-                        help='The path to notebooks you wish to convert.')
-
     return parser
 
 


### PR DESCRIPTION
When trying to execute the `jwst-validation-notebooks` with a Jenkins build, if I use the default `'.'` argument, the entire Jenkins workspace is combed for notebooks. This cause my builds to fail because there are notebooks stashed in the `matplotlib` library which are also checked for executed cells. This change will allow me (or anyone else) to specify the location for notebooks to avoid this problem in the future.